### PR TITLE
Removed requester from input in zendesk trigger

### DIFF
--- a/triggers/zenddesk_error_job_trigger/zenddesk_error_job_trigger.lua
+++ b/triggers/zenddesk_error_job_trigger/zenddesk_error_job_trigger.lua
@@ -31,7 +31,7 @@ function post_create_error_ticket(p)
 
 			local ticketBody = ""
 			ticketBody = ticketBody .. "Error happened on Job:" .. p.input:getJobType():toString() .. "\nJob UUID:" .. p.input:getResourceUUID() .. "\nJob Item ID:" .. p.input:getItemUUID()
-			local input = { ticket = { requester ={ name = p.input:getCustomerName() , email = p.user:getEmail()}, subject = p.input:getItemDescription(), comment = {body = ticketBody}, type = "problem"}, priority = priorityKeyValue}
+			local input = { ticket = { subject = p.input:getItemDescription(), comment = {body = ticketBody}, type = "problem"}, priority = priorityKeyValue}
 			local js = new ("JSON")
 			local params = js:encode(input)
 


### PR DESCRIPTION
Using requester produces

```
{"error":"RecordInvalid","description":"Record validation errors","details":{"requester":[{"description"
:"Requester Name:  is too short (minimum one character)"}]}}
```

Testing using multiple customers accounts the requester was always set to "jobs-queue@dummy.flexiant.com" anyway.
